### PR TITLE
Compiling in VS2012

### DIFF
--- a/examples/netdump/netdump.c
+++ b/examples/netdump/netdump.c
@@ -76,7 +76,7 @@ int __cdecl main(int argc, char **argv)
     console = GetStdHandle(STD_OUTPUT_HANDLE);
 
     // Divert traffic matching the filter:
-    handle = DivertOpen(argv[1], 0, priority, DIVERT_FLAG_SNIFF);
+    handle = DivertOpen(argv[1], (DIVERT_LAYER)0, priority, DIVERT_FLAG_SNIFF);
     if (handle == INVALID_HANDLE_VALUE)
     {
         if (GetLastError() == ERROR_INVALID_PARAMETER)

--- a/examples/netfilter/netfilter.c
+++ b/examples/netfilter/netfilter.c
@@ -149,7 +149,7 @@ int __cdecl main(int argc, char **argv)
     console = GetStdHandle(STD_OUTPUT_HANDLE);
 
     // Divert traffic matching the filter:
-    handle = DivertOpen(argv[1], 0, priority, 0);
+    handle = DivertOpen(argv[1], (DIVERT_LAYER)0, priority, 0);
     if (handle == INVALID_HANDLE_VALUE)
     {
         if (GetLastError() == ERROR_INVALID_PARAMETER)

--- a/examples/passthru/passthru.c
+++ b/examples/passthru/passthru.c
@@ -56,7 +56,7 @@ int __cdecl main(int argc, char **argv)
     }
 
     // Divert traffic matching the filter:
-    handle = DivertOpen(argv[1], 0, 0, 0);
+    handle = DivertOpen(argv[1], (DIVERT_LAYER)0, 0, 0);
     if (handle == INVALID_HANDLE_VALUE)
     {
         if (GetLastError() == ERROR_INVALID_PARAMETER)

--- a/examples/webfilter/webfilter.c
+++ b/examples/webfilter/webfilter.c
@@ -163,7 +163,7 @@ int __cdecl main(int argc, char **argv)
             "ip && "                    // Only IPv4 supported
             "tcp.DstPort == 80 && "     // HTTP (port 80) only
             "tcp.PayloadLength > 0",    // TCP data packets only
-            0, priority, 0
+            (DIVERT_LAYER)0, priority, 0
         );
     if (handle == INVALID_HANDLE_VALUE)
     {


### PR DESCRIPTION
Casting the divert layer argument for the DivertOpen function resolves
a type error in VS2012.
