### PR TITLE
Fix documentation, the default packet queue length is 1024

### DIFF
--- a/doc/windivert.html
+++ b/doc/windivert.html
@@ -857,7 +857,7 @@ Description
 <td>
 Sets the maximum length of the packet queue for
 <a href="#divert_recv"><tt>WinDivertRecv()</tt></a>.
-Currently the default value is 512, the minimum is 1, and the maximum 
+Currently the default value is 1024, the minimum is 1, and the maximum
 is 8192.
 </td>
 </tr>


### PR DESCRIPTION
WINDIVERT_PARAM_QUEUE_LEN_DEFAULT was updated to 1024 in https://github.com/basil00/Divert/commit/38f1f3a16d29f3af299ca398cc93983edde5921f

Besides, QUEUE_SIZE_MIN is 65535 in code but 4096 in documentation. I am not sure which one is right.

https://github.com/basil00/Divert/blob/c4575b7059ad8933c81c4f4cc583f53ad69154b1/include/windivert_device.h#L160

https://github.com/basil00/Divert/blob/c4575b7059ad8933c81c4f4cc583f53ad69154b1/doc/windivert.html#L887